### PR TITLE
Fix playback track could update .computed rating to .user rating issue

### DIFF
--- a/NepTunes/MusicPlayer.m
+++ b/NepTunes/MusicPlayer.m
@@ -508,10 +508,11 @@ NSString * const kCannotGetInfoFromSpotify = @"cannotGetInfoFromSpotify";
 -(void)updateRating:(NSNotification *)note
 {
     if (self.currentPlayer == MusicPlayeriTunes) {
-        if (self._currentiTunesTrack.ratingKind == iTunesERtKComputed) {
+        NSInteger newRating = ((Track *)note.object).rating;
+        if ((self._currentiTunesTrack.ratingKind == iTunesERtKComputed) && (self._currentiTunesTrack.rating == newRating)) {
             return ;
         }
-        self._currentiTunesTrack.rating = ((Track *)note.object).rating;
+        self._currentiTunesTrack.rating = newRating;
     }
 }
 

--- a/NepTunes/MusicPlayer.m
+++ b/NepTunes/MusicPlayer.m
@@ -508,6 +508,9 @@ NSString * const kCannotGetInfoFromSpotify = @"cannotGetInfoFromSpotify";
 -(void)updateRating:(NSNotification *)note
 {
     if (self.currentPlayer == MusicPlayeriTunes) {
+        if (self._currentiTunesTrack.ratingKind == iTunesERtKComputed) {
+            return ;
+        }
         self._currentiTunesTrack.rating = ((Track *)note.object).rating;
     }
 }


### PR DESCRIPTION
<img width="855" alt="" src="https://user-images.githubusercontent.com/7940186/63180157-3e97e680-c080-11e9-87b7-84b685844f96.png">


iTunes v12.9.5.5 always mark track rating and give ratingKind (iTunesERtK). And in Track.m the rating setter post the `kTrackRatingWasSetNotificationName` notification cause the `_currentiTunesTrack.rating` update whenever the rating is .computed or .user. 

Before update the rating. Check the ratingKind should fix it. 
