### PR TITLE
Use "correct" ❤️ emoji in notification

### DIFF
--- a/NepTunes/UserNotificationsController.m
+++ b/NepTunes/UserNotificationsController.m
@@ -87,7 +87,7 @@
         NSUserNotification *notification = [[NSUserNotification alloc] init];
         [notification setTitle:[NSString stringWithFormat:@"%@", track.artist]];
         if ([SettingsController sharedSettings].cutExtraTags) {
-            [notification setInformativeText:[NSString stringWithFormat:@"%@ ♥️ at Last.fm", [[[MusicScrobbler sharedScrobbler] stringsWithRemovedUnwantedTagsFromTrack:track] firstObject]]];
+            [notification setInformativeText:[NSString stringWithFormat:@"%@ ❤️ at Last.fm", [[[MusicScrobbler sharedScrobbler] stringsWithRemovedUnwantedTagsFromTrack:track] firstObject]]];
         } else {
             [notification setInformativeText:[NSString stringWithFormat:@"%@ ❤️ at Last.fm", track.trackName]];
         }


### PR DESCRIPTION
This is likely the most petty PR ever 😅 

First of all thanks for making NepTunes! I've been looking for a modern and minimal Last.fm client for macOS for ages and finally stumbled across NepTunes. It works and runs fantastically, thank you so much!

The tiniest thing bugging me however is the fact that I'm seeing :hearts: in notifications when loving a song. :hearts: is part of the set of emoji for playing cards, like ♦️, ♣️ and ♠️. It doesn't really carry the same semantics as ❤️ or any of the other hearts do.

Now I know I'm arguing semantics of emoji here, which is beyond ridiculous. They constantly get redefined and used in other contexts, just like 🙏 being used for praying, thank you and high fives, so feel free to completely ignore this PR altogether. But you'd definitely make me happy if you update the emoji used there 😅 